### PR TITLE
Update Caddyfile

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,11 +1,11 @@
 {
-  http_port 8080
-  log {
-      output discard
-  }
+	http_port 8080
+	log {
+		output discard
+	}
 }
 
 localhost:8546 {
-  tls internal
-  reverse_proxy localhost:8545
+	tls internal
+	reverse_proxy localhost:8545
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,5 @@
 {
+  http_port 8080
   log {
       output discard
   }


### PR DESCRIPTION
caddy needs the extra config `http_port xxxx` in order to work for me, likely for others, too. This is the error message if it is not present:

```
Error: loading initial config: loading new config: http app module: start: listening on :80: listen tcp :80: bind: permission denied
Error: caddy process exited with error: exit status 1
```

If I remember correctly this is because the default of port 80 can be accessed by root only, and we are operating as user when running `./deploy.sh` directly.