### PR TITLE
Add L2 RpcServices types

### DIFF
--- a/packages/evm-rpc-canister-types/evm_rpc.did
+++ b/packages/evm-rpc-canister-types/evm_rpc.did
@@ -36,6 +36,7 @@ type EthMainnetService = variant {
   BlockPi;
   Cloudflare;
   PublicNode;
+  Llama;
 };
 type EthSepoliaService = variant {
   Alchemy;
@@ -48,6 +49,7 @@ type L2MainnetService = variant {
   Ankr;
   BlockPi;
   PublicNode;
+  Llama;
 };
 type FeeHistory = record {
   reward : vec vec nat;
@@ -93,6 +95,7 @@ type LogEntry = record {
 };
 type ManageProviderArgs = record {
   providerId : nat64;
+  chainId: opt nat64;
   "service" : opt RpcService;
   primary : opt bool;
 };

--- a/packages/evm-rpc-canister-types/evm_rpc.did
+++ b/packages/evm-rpc-canister-types/evm_rpc.did
@@ -36,7 +36,6 @@ type EthMainnetService = variant {
   BlockPi;
   Cloudflare;
   PublicNode;
-  Llama;
 };
 type EthSepoliaService = variant {
   Alchemy;
@@ -49,7 +48,6 @@ type L2MainnetService = variant {
   Ankr;
   BlockPi;
   PublicNode;
-  Llama;
 };
 type FeeHistory = record {
   reward : vec vec nat;
@@ -95,7 +93,6 @@ type LogEntry = record {
 };
 type ManageProviderArgs = record {
   providerId : nat64;
-  chainId: opt nat64;
   "service" : opt RpcService;
   primary : opt bool;
 };

--- a/packages/evm-rpc-canister-types/src/lib.rs
+++ b/packages/evm-rpc-canister-types/src/lib.rs
@@ -45,10 +45,21 @@ pub enum EthMainnetService {
 }
 
 #[derive(CandidType, Deserialize, Debug, Clone)]
+pub enum L2MainnetService {
+    Alchemy,
+    Ankr,
+    BlockPi,
+    PublicNode,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
 pub enum RpcServices {
     EthSepolia(Option<Vec<EthSepoliaService>>),
     Custom { chainId: u64, services: Vec<RpcApi> },
     EthMainnet(Option<Vec<EthMainnetService>>),
+    ArbitrumOne(Option<Vec<L2MainnetService>>),
+    BaseMainnet(Option<Vec<L2MainnetService>>),
+    Optimism(Option<Vec<L2MainnetService>>),
 }
 
 #[derive(CandidType, Deserialize, Debug, Clone)]
@@ -153,6 +164,9 @@ pub enum RpcService {
     EthMainnet(EthMainnetService),
     Chain(u64),
     Provider(u64),
+    ArbitrumOne(L2MainnetService),
+    BaseMainnet(L2MainnetService),
+    OptimismMainnet(L2MainnetService),
 }
 
 #[derive(CandidType, Deserialize, Debug, Clone)]


### PR DESCRIPTION
RpcServices types should include support for the newly added L2 chains.