### PR TITLE
Extend ic evm utils with already known tx status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,6 +1109,7 @@ dependencies = [
  "candid",
  "ethers-core",
  "evm-rpc-canister-types 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom",
  "ic-cdk 0.14.0",
  "num-traits",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,13 +291,13 @@ version = "0.1.0"
 dependencies = [
  "candid",
  "ethers-core",
- "evm-rpc-canister-types 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "evm-rpc-canister-types",
  "getrandom",
  "hex",
  "ic-canisters-http-types",
  "ic-cdk 0.14.0",
  "ic-cdk-timers",
- "ic-evm-utils 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-evm-utils",
  "ic-stable-structures",
  "minicbor",
  "minicbor-derive",
@@ -625,41 +625,10 @@ dependencies = [
 
 [[package]]
 name = "evm-rpc-canister-types"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26317f516fb0bc1e0e49083865484df312566bef8e4e4b84f492dd552192dd5a"
-dependencies = [
- "candid",
- "candid_parser",
- "ic-cdk 0.14.0",
- "reqwest",
- "serde",
- "serde_bytes",
- "serde_json",
-]
-
-[[package]]
-name = "evm-rpc-canister-types"
 version = "1.0.0"
 dependencies = [
  "candid",
  "candid_parser",
- "ic-cdk 0.14.0",
- "reqwest",
- "serde",
- "serde_bytes",
- "serde_json",
-]
-
-[[package]]
-name = "evm-rpc-canister-types"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b0da276d418ffaad13b7348d94182b597a43339b6852806dbdcdadb6749d31"
-dependencies = [
- "candid",
- "candid_parser",
- "evm-rpc-canister-types 0.1.2",
  "ic-cdk 0.14.0",
  "reqwest",
  "serde",
@@ -1108,24 +1077,8 @@ version = "1.0.0"
 dependencies = [
  "candid",
  "ethers-core",
- "evm-rpc-canister-types 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "evm-rpc-canister-types",
  "getrandom",
- "ic-cdk 0.14.0",
- "num-traits",
- "serde",
- "serde_bytes",
- "serde_json",
-]
-
-[[package]]
-name = "ic-evm-utils"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae5163ad493747b9c2e29b09ba2c22b2800545c2030d29a01309eada92ab8179"
-dependencies = [
- "candid",
- "ethers-core",
- "evm-rpc-canister-types 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-cdk 0.14.0",
  "num-traits",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ serde = "1.0.197"
 serde_bytes = "0.11.14"
 serde_json = "1.0.116"
 ethers-core = "2.0.14"
-ic-evm-utils = "1.0.0"
-evm-rpc-canister-types = "1.0.0"
+ic-evm-utils = { path = "packages/ic-evm-utils" }
+evm-rpc-canister-types = { path = "packages/evm-rpc-canister-types" }

--- a/packages/evm-rpc-canister-types/src/lib.rs
+++ b/packages/evm-rpc-canister-types/src/lib.rs
@@ -299,6 +299,7 @@ pub enum SendRawTransactionStatus {
     NonceTooLow,
     NonceTooHigh,
     InsufficientFunds,
+    AlreadyKnown,
 }
 
 #[derive(CandidType, Deserialize, Debug, Clone)]

--- a/packages/ic-evm-utils/Cargo.toml
+++ b/packages/ic-evm-utils/Cargo.toml
@@ -27,3 +27,4 @@ serde_json.workspace = true
 ethers-core.workspace = true
 num-traits = "0.2.19"
 evm-rpc-canister-types.workspace = true
+getrandom = { features = ["custom"] }

--- a/packages/ic-evm-utils/src/eth_send_raw_transaction.rs
+++ b/packages/ic-evm-utils/src/eth_send_raw_transaction.rs
@@ -223,7 +223,11 @@ pub async fn send_raw_transaction(
             MultiSendRawTransactionResult::Consistent(status) => match status {
                 SendRawTransactionResult::Ok(status) => status,
                 SendRawTransactionResult::Err(e) => {
-                    ic_cdk::trap(format!("Error: {:?}", e).as_str());
+                    if format!("Error: {:?}", e).as_str().contains("-32010") {
+                        return SendRawTransactionStatus::AlreadyKnown;
+                    } else {
+                        ic_cdk::trap(format!("Error: {:?}", e).as_str())
+                    }
                 }
             },
             MultiSendRawTransactionResult::Inconsistent(_) => {


### PR DESCRIPTION
# Motivation

Currently, the -32010 response from an rpc endpoint is interpreted as error within the ic-evm-utils library.

As discussed [here](https://forum.dfinity.org/t/chain-fusion-error-32010-alreadyknown-when-sending-tx/34911/5), the `-32010: AlreadyKnown` response from an evm rpc endpoint is not a classical error. Rather, it signals that the exact transaction being pushed is in the mempool. The application should have the option to treat this status is an appropriate manner, for example:
- waiting for the tx to be mined 
- waiting for the tx to be dropped
- assuming that the tx will be mined ([example](https://github.com/malteish/ReTransICP/blob/2b267fb2a9b85607c992bb304f8d161eff04b848/canisters/chain_fusion/src/job/submit_result.rs#L68))

# Changes

1. extend the status enum
2. check for the error code and respond with the new status instead of an error in this specific case only
3. update cargo.toml to actually use the local packages

